### PR TITLE
Support for preview releases (alpha|beta|rc) in Haxe version lists

### DIFF
--- a/hvm.sh
+++ b/hvm.sh
@@ -11,7 +11,6 @@ hvm_get_haxe_versions() {
 		'LINUX32') local DOWNLOAD="href='haxe-${VERSION}-linux\(32\)\?.tar\.gz'" ;;
 		'LINUX64') local DOWNLOAD="href=\"haxe-${VERSION}-linux64.tar.gz\"" ;;
 	esac
-	echo $DOWNLOAD
 	HAXE_VERSIONS=()
 	local VERSIONS=$( curl --silent http://old.haxe.org/file/ 2>&1 | grep -o $DOWNLOAD | sed "s/[^0-9]*\($VERSION\).*/\1/" )
 	for VERSION in $VERSIONS; do

--- a/hvm.sh
+++ b/hvm.sh
@@ -7,8 +7,8 @@ hvm_get_haxe_versions() {
 	PREVIEW="\(-\(alpha\|beta\|rc\)[0-9]\)\?"
 	VERSION="[^-]*${PREVIEW}"
 	case $PLATFORM in
-		'OSX') local DOWNLOAD="href='haxe-${VERSION}-osx.tar\.gz'" ;;
-		'LINUX32') local DOWNLOAD="href='haxe-${VERSION}-linux\(32\)\?.tar\.gz'" ;;
+		'OSX') local DOWNLOAD="href=\"haxe-${VERSION}-osx.tar\.gz\"" ;;
+		'LINUX32') local DOWNLOAD="href=\"haxe-${VERSION}-linux\(32\)\?.tar\.gz\"" ;;
 		'LINUX64') local DOWNLOAD="href=\"haxe-${VERSION}-linux64.tar.gz\"" ;;
 	esac
 	HAXE_VERSIONS=()

--- a/hvm.sh
+++ b/hvm.sh
@@ -4,13 +4,16 @@ source $HVM/versions.sh
 source $HVM/platform.sh
 
 hvm_get_haxe_versions() {
+	PREVIEW="\(-\(alpha\|beta\|rc\)[0-9]\)\?"
+	VERSION="[^-]*${PREVIEW}"
 	case $PLATFORM in
-		'OSX') local DOWNLOAD='href="haxe-[^-]*-osx.tar\.gz' ;;
-		'LINUX32') local DOWNLOAD='href="haxe-[^-]*-linux\(32\)\?.tar\.gz' ;;
-		'LINUX64') local DOWNLOAD='href="haxe-[^-]*-linux64.tar\.gz' ;;
+		'OSX') local DOWNLOAD="href='haxe-${VERSION}-osx.tar\.gz'" ;;
+		'LINUX32') local DOWNLOAD="href='haxe-${VERSION}-linux\(32\)\?.tar\.gz'" ;;
+		'LINUX64') local DOWNLOAD="href=\"haxe-${VERSION}-linux64.tar.gz\"" ;;
 	esac
+	echo $DOWNLOAD
 	HAXE_VERSIONS=()
-	local VERSIONS=$( curl --silent http://old.haxe.org/file/ 2>&1 | grep -o $DOWNLOAD | sed 's/[^0-9]*\([^-]*\).*/\1/' )
+	local VERSIONS=$( curl --silent http://old.haxe.org/file/ 2>&1 | grep -o $DOWNLOAD | sed "s/[^0-9]*\($VERSION\).*/\1/" )
 	for VERSION in $VERSIONS; do
 		HAXE_VERSIONS+=($VERSION)
 	done


### PR DESCRIPTION
This provides support for the preview version numbers, so they don't get filtered out.
